### PR TITLE
Implement row-level filtering

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -20,7 +20,7 @@
   - [x] `Membership` model (role: Parent / Child / Guest).
   - [x] Invitation & accept flow.
 - [x] Integrate Django REST Framework & simple-jwt.
-- [ ] Global row-level filtering by `family_id` via custom DRF permissions & querysets.
+- [x] Global row-level filtering by `family_id` via custom DRF permissions & querysets.
 
 ## Phase 2 – Domain Apps
 

--- a/backend/apps/families/models.py
+++ b/backend/apps/families/models.py
@@ -6,6 +6,19 @@ from django.db import models
 from django.utils.crypto import get_random_string
 
 
+class FamilyScopedModel(TimeStampedModel):
+    """Abstract base model carrying a ``family`` foreign key."""
+
+    family = models.ForeignKey(
+        "families.Family",
+        on_delete=models.CASCADE,
+        related_name="%(app_label)s_%(class)ss",
+    )
+
+    class Meta:
+        abstract = True
+
+
 class Family(TimeStampedModel):
     """A group of users managed together."""
 

--- a/backend/apps/families/permissions.py
+++ b/backend/apps/families/permissions.py
@@ -2,12 +2,33 @@
 
 from rest_framework import permissions
 
-from .models import Membership
+from .models import Family, Membership
 
 
 class IsFamilyMember(permissions.BasePermission):
-    """Allows access only to members of a family."""
+    """Allow access if the user belongs to the object's family."""
 
     def has_object_permission(self, request, view, obj):
         user = request.user
-        return Membership.objects.filter(user=user, family=obj).exists()
+        if isinstance(obj, Family):
+            family = obj
+        else:
+            family = getattr(obj, "family", None)
+
+        if family is None:
+            return False
+
+        return Membership.objects.filter(user=user, family=family).exists()
+
+    def has_permission(self, request, view):
+        return request.user and request.user.is_authenticated
+
+
+class HasFamilyAccess(permissions.BasePermission):
+    """Generic permission using an object's ``family`` attribute."""
+
+    def has_object_permission(self, request, view, obj):
+        family = getattr(obj, "family", None)
+        if family is None:
+            return False
+        return Membership.objects.filter(user=request.user, family=family).exists()

--- a/backend/apps/families/tests.py
+++ b/backend/apps/families/tests.py
@@ -2,6 +2,7 @@
 
 from apps.core.models import User
 from django.test import TestCase
+from rest_framework.test import APIClient
 
 from .models import Family, Invitation, Membership
 
@@ -28,3 +29,38 @@ class FamiliesModelTests(TestCase):
             Membership.objects.filter(user=new_user, family=self.family).exists()
         )
         self.assertTrue(invite.accepted)
+
+
+class FamilyAPITests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.owner = User.objects.create_user("owner@example.com", "pass")
+        self.other_user = User.objects.create_user("other@example.com", "pass")
+        self.family = Family.objects.create(name="Smith", owner=self.owner)
+        Membership.objects.create(
+            user=self.owner, family=self.family, role=Membership.Role.PARENT
+        )
+        self.url = "/api/families/"
+
+    def test_list_returns_only_member_families(self):
+        other_family = Family.objects.create(name="Jones", owner=self.other_user)
+        Membership.objects.create(
+            user=self.other_user, family=other_family, role=Membership.Role.PARENT
+        )
+
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["id"], self.family.id)
+
+    def test_cannot_access_non_member_family(self):
+        other_family = Family.objects.create(name="Jones", owner=self.other_user)
+        Membership.objects.create(
+            user=self.other_user, family=other_family, role=Membership.Role.PARENT
+        )
+
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.get(f"{self.url}{other_family.id}/")
+        self.assertEqual(response.status_code, 404)

--- a/backend/apps/families/views.py
+++ b/backend/apps/families/views.py
@@ -1,5 +1,6 @@
 """API views for the families app."""
 
+from django.db.models import Q
 from rest_framework import permissions, viewsets
 
 from .models import Family
@@ -14,14 +15,33 @@ class IsFamilyOwner(permissions.BasePermission):
 
 
 class FamilyViewSet(viewsets.ModelViewSet):
-    """CRUD for families."""
+    """CRUD for families with membership-based filtering."""
 
-    queryset = Family.objects.all()
     serializer_class = FamilySerializer
-    permission_classes = [permissions.IsAuthenticated, IsFamilyOwner]
+
+    def get_permissions(self):
+        if self.action in {"update", "partial_update", "destroy"}:
+            perms = [permissions.IsAuthenticated, IsFamilyOwner]
+        else:
+            from .permissions import IsFamilyMember
+
+            perms = [permissions.IsAuthenticated, IsFamilyMember]
+        return [p() for p in perms]
 
     def perform_create(self, serializer):
-        serializer.save(owner=self.request.user)
+        from .models import Membership
+
+        family = serializer.save(owner=self.request.user)
+        Membership.objects.create(
+            user=self.request.user,
+            family=family,
+            role=Membership.Role.PARENT,
+        )
 
     def get_queryset(self):
-        return Family.objects.filter(owner=self.request.user)
+        user = self.request.user
+        return (
+            Family.objects.filter(Q(owner=user) | Q(memberships__user=user))
+            .distinct()
+            .order_by("id")
+        )

--- a/doc/DETAILED_TASKS.md
+++ b/doc/DETAILED_TASKS.md
@@ -19,7 +19,7 @@ This document expands the high-level items in `TASKS.md`.
   - `Family` and `Membership` models.
   - Invitation generation and acceptance views.
 - Integrate Django REST Framework and simple JWT authentication.
-- Implement row-level filtering for `family_id` via DRF permissions and querysets. *(in progress)*
+- Implement row-level filtering for `family_id` via DRF permissions and querysets. ✅
 
 ## Phase 2 – Domain Apps
 ### Chores


### PR DESCRIPTION
## Summary
- add `FamilyScopedModel` base class
- broaden family permissions
- filter families by membership in viewset
- test API-level access controls
- mark row-level filtering tasks complete

## Testing
- `pre-commit run --files TASKS.md backend/apps/families/models.py backend/apps/families/permissions.py backend/apps/families/tests.py backend/apps/families/views.py doc/DETAILED_TASKS.md`
- `FAMPLUS_SQLITE=1 python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_686a0a00135c83208c42038e11e6ffbf