### PR TITLE
Add domain app docs

### DIFF
--- a/doc/DETAILED_TASKS.md
+++ b/doc/DETAILED_TASKS.md
@@ -23,21 +23,25 @@ This document expands the high-level items in `TASKS.md`.
 
 ## Phase 2 – Domain Apps
 ### Chores
+- [Detailed design](chores.md)
 - Port `Chore` and `Entry` models from the old project.
 - Write CRUD API endpoints and approval workflows.
 - Schedule Celery tasks for automatic entry creation.
 
 ### Accounting
+- [Detailed design](accounting.md)
 - Define `Account`, `Category`, `Transaction` and `Journal` models.
 - Enforce double-entry accounting rules and provide balance helpers.
 - Provide import/export endpoints for transactions.
 
 ### Assets
+- [Detailed design](assets.md)
 - Implement `Asset`, `Price` and `AssetTransactionLink` models.
 - Service for fetching prices from CoinGecko.
 - Gain strategy calculations (FIFO / LIFO / MAX gain).
 
 ### Notifications (optional)
+- [Detailed design](notifications.md)
 - Email and push notifications for due chores and approvals.
 
 ## Phase 3 – Frontend Foundation

--- a/doc/accounting.md
+++ b/doc/accounting.md
@@ -1,0 +1,19 @@
+# Accounting App
+
+Details for the lightweight double-entry accounting features.
+
+## Models
+- `Account` – chart of accounts with type (Asset, Expense, Liability, etc.).
+- `Category` – user-defined tags for transactions.
+- `Transaction` – a single monetary change posted to two accounts.
+- `Journal` – grouping of transactions for imports or batch operations.
+
+## Endpoints
+- `GET /api/accounts/` – list and manage accounts.
+- `GET /api/transactions/` – list transactions with filters.
+- `POST /api/transactions/` – create a new double-entry transaction.
+- `POST /api/transactions/import/` – bulk upload from CSV.
+
+## Background Tasks
+- Daily summary job to update account balances.
+- Optional export of monthly statements via email.

--- a/doc/assets.md
+++ b/doc/assets.md
@@ -1,0 +1,18 @@
+# Assets App
+
+Handles tracking of investments or collectibles.
+
+## Models
+- `Asset` – represents an individual asset such as a crypto coin or share.
+- `Price` – timestamped value of an asset in a reference currency.
+- `AssetTransactionLink` – ties accounting transactions to asset movements.
+
+## Endpoints
+- `GET /api/assets/` – list assets in the portfolio.
+- `POST /api/assets/` – add a new asset.
+- `GET /api/asset-prices/` – retrieve historical price data.
+- `POST /api/portfolio/realise/` – compute gains for disposals.
+
+## Background Tasks
+- Periodic fetch of latest prices from CoinGecko.
+- Gain strategy calculation jobs (FIFO/LIFO/MAX gain).

--- a/doc/chores.md
+++ b/doc/chores.md
@@ -1,0 +1,18 @@
+# Chores App
+
+Detailed breakdown of the chores domain.
+
+## Models
+- `Chore` – template describing the task, schedule and point value.
+- `Entry` – individual occurrence of a chore awaiting completion and approval.
+
+## Endpoints
+- `GET /api/chores/` – list and filter chores.
+- `POST /api/chores/` – create a new chore.
+- `PATCH /api/chores/{id}/` – update or archive a chore.
+- `POST /api/chore-entries/` – log completion of a chore entry.
+- `POST /api/chore-entries/{id}/approve/` – parent approval action.
+
+## Background Tasks
+- Celery beat job spawns `Entry` records based on each `Chore`'s schedule.
+- Reminder emails or push notifications for due chores.

--- a/doc/notifications.md
+++ b/doc/notifications.md
@@ -1,0 +1,15 @@
+# Notifications App
+
+Central place for user alerts and reminders.
+
+## Models
+- `NotificationPreference` – user-specific settings for email/push.
+- `Notification` – stored message with read state.
+
+## Endpoints
+- `GET /api/notifications/` – list recent notifications for the user.
+- `POST /api/notifications/mark-read/` – bulk mark as read.
+
+## Background Tasks
+- Celery tasks for sending emails and push notifications.
+- Scheduled reminders for due chore approvals or account updates.


### PR DESCRIPTION
## Summary
- create docs for Chores, Accounting, Assets and Notifications apps
- link new docs in `doc/DETAILED_TASKS.md`

## Testing
- `FAMPLUS_SQLITE=1 python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_686a1a721320832085398cf00fbcd41a