### PR TITLE
Enable SQLite test runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ famplus/
 3. Run service helper → `./scripts/setup_services.sh` (installs & starts MySQL/Redis and optional MailHog).
 4. Install pre‑commit → `pip install pre-commit` then `pre-commit install`.
 5. Run the dev server → `cd backend && python manage.py runserver`.
+6. Run tests using SQLite (set `FAMPLUS_SQLITE=1`) → `./scripts/run_tests_sqlite.sh`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -106,9 +106,24 @@ famplus/
 1. Clone repo → `git clone <this repo>`
 2. Install Python & Node requirements.
 3. Run service helper → `./scripts/setup_services.sh` (installs & starts MySQL/Redis and optional MailHog).
-4. Install pre‑commit → `pip install pre-commit` then `pre-commit install`.
-5. Run the dev server → `cd backend && python manage.py runserver`.
-6. Run tests using SQLite (set `FAMPLUS_SQLITE=1`) → `./scripts/run_tests_sqlite.sh`
+4. Configure environment variables (see list below).
+5. Install pre‑commit → `pip install pre-commit` then `pre-commit install`.
+6. Run the dev server → `cd backend && python manage.py runserver`.
+7. Run tests using SQLite (set `FAMPLUS_SQLITE=1`) → `./scripts/run_tests_sqlite.sh`
+
+### Required Environment Variables
+Set these before running the backend (a `.env` file works too):
+
+```
+SECRET_KEY=<your secret>
+DB_NAME=famplusdb
+DB_USER=famplususer
+DB_PASSWORD=<password>
+DB_HOST=127.0.0.1
+DB_PORT=3306
+```
+
+Optionally set `FAMPLUS_SQLITE=1` to use SQLite instead of MySQL.
 
 ---
 

--- a/backend/project/settings.py
+++ b/backend/project/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/5.0/ref/settings/
 """
 
 import os
+import sys
 from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -78,11 +79,11 @@ WSGI_APPLICATION = "project.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/5.0/ref/settings/#databases
 
-if os.environ.get("FAMPLUS_SQLITE"):
+if os.environ.get("FAMPLUS_SQLITE") and "test" in sys.argv:
     DATABASES = {
         "default": {
             "ENGINE": "django.db.backends.sqlite3",
-            "NAME": BASE_DIR / "db.sqlite3",
+            "NAME": BASE_DIR / "test.sqlite3",
         }
     }
 else:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,3 +1,6 @@
 # Helper scripts
 
 `setup_services.sh` installs and starts local MySQL, Redis and optional MailHog.
+
+`run_tests_sqlite.sh` runs the Django test suite using a temporary SQLite
+database (no MySQL required).

--- a/scripts/run_tests_sqlite.sh
+++ b/scripts/run_tests_sqlite.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/../backend"
+FAMPLUS_SQLITE=1 python manage.py test "$@"


### PR DESCRIPTION
## Summary
- use SQLite only when running tests with `FAMPLUS_SQLITE=1`
- add helper script for running Django tests with SQLite
- document test instructions in README and scripts/README

## Testing
- `pre-commit run --files README.md backend/project/settings.py scripts/README.md scripts/run_tests_sqlite.sh`
- `./scripts/run_tests_sqlite.sh`

------
https://chatgpt.com/codex/tasks/task_e_686a1a6d9e2483208bc7990ef5a2f340