### PR TITLE
Add Celery integration and daily entry task

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ famplus/
 5. Install pre‑commit → `pip install pre-commit` then `pre-commit install`.
 6. Run the dev server → `cd backend && python manage.py runserver`.
 7. Run tests using SQLite (set `FAMPLUS_SQLITE=1`) → `./scripts/run_tests_sqlite.sh`
+8. Start Celery worker & beat → `cd backend && celery -A project worker -B --loglevel=info`
 
 ### Required Environment Variables
 Set these before running the backend (a `.env` file works too):
@@ -121,6 +122,8 @@ DB_USER=famplususer
 DB_PASSWORD=<password>
 DB_HOST=127.0.0.1
 DB_PORT=3306
+CELERY_BROKER_URL=redis://127.0.0.1:6379/0
+CELERY_RESULT_BACKEND=redis://127.0.0.1:6379/0
 ```
 
 Optionally set `FAMPLUS_SQLITE=1` to use SQLite instead of MySQL.

--- a/backend/apps/chores/tasks.py
+++ b/backend/apps/chores/tasks.py
@@ -1,0 +1,18 @@
+from datetime import date, timedelta
+
+from celery import shared_task
+
+from .models import Chore, Entry
+
+
+@shared_task
+def spawn_entries():
+    """Create upcoming chore entries for active chores."""
+    tomorrow = date.today() + timedelta(days=1)
+    for chore in Chore.objects.filter(archived=False):
+        Entry.objects.get_or_create(
+            family=chore.family,
+            chore=chore,
+            assigned_to=chore.family.owner,
+            due_date=tomorrow,
+        )

--- a/backend/apps/chores/tests.py
+++ b/backend/apps/chores/tests.py
@@ -5,6 +5,7 @@ from apps.families.models import Family, Membership
 from django.test import TestCase
 
 from .models import Chore, Entry
+from .tasks import spawn_entries
 
 
 class ChoreModelTests(TestCase):
@@ -27,3 +28,10 @@ class ChoreModelTests(TestCase):
         )
         self.assertEqual(entry.chore, chore)
         self.assertEqual(entry.status, Entry.Status.AWAITING)
+
+    def test_spawn_entries_task(self):
+        Chore.objects.create(
+            family=self.family, name="Vacuum", schedule="daily", points=2
+        )
+        spawn_entries()
+        self.assertTrue(Entry.objects.filter(chore__name="Vacuum").exists())

--- a/backend/project/__init__.py
+++ b/backend/project/__init__.py
@@ -1,0 +1,3 @@
+from .celery import app as celery_app
+
+__all__ = ["celery_app"]

--- a/backend/project/celery.py
+++ b/backend/project/celery.py
@@ -1,0 +1,15 @@
+import os
+
+from celery import Celery
+from django.conf import settings
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "project.settings")
+
+app = Celery("famplus")
+app.config_from_object("django.conf:settings", namespace="CELERY")
+app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
+
+
+@app.task(bind=True)
+def debug_task(self):
+    print(f"Request: {self.request!r}")

--- a/backend/project/settings.py
+++ b/backend/project/settings.py
@@ -15,6 +15,7 @@ import sys
 from pathlib import Path
 
 import environ
+from celery.schedules import crontab
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -161,3 +162,14 @@ REST_FRAMEWORK = {
 # https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+# Celery configuration
+CELERY_BROKER_URL = env("CELERY_BROKER_URL", default="redis://127.0.0.1:6379/0")
+CELERY_RESULT_BACKEND = env("CELERY_RESULT_BACKEND", default=CELERY_BROKER_URL)
+
+CELERY_BEAT_SCHEDULE = {
+    "spawn_entries": {
+        "task": "apps.chores.tasks.spawn_entries",
+        "schedule": crontab(minute=0, hour=0),
+    }
+}


### PR DESCRIPTION
## Summary
- configure Celery app and daily beat schedule
- add spawn_entries task for chores
- update README instructions and environment variables
- test the spawn_entries task

## Testing
- `pre-commit run --files backend/project/celery.py backend/project/__init__.py backend/apps/chores/tasks.py backend/project/settings.py backend/apps/chores/tests.py README.md`
- `./scripts/run_tests_sqlite.sh`

------
https://chatgpt.com/codex/tasks/task_e_686a234b321c8320b26e06f0a3a24a08