### PR TITLE
Implement accounting features with import/export

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -31,8 +31,8 @@
 
 ### 2.2 Accounting
 - [x] Models: `Account`, `Category`, `Transaction`, `Journal`.
-- [ ] Double-entry constraints & balance helpers.
-- [ ] Endpoint for transaction import/export.
+- [x] Double-entry constraints & balance helpers.
+- [x] Endpoint for transaction import/export.
 
 ### 2.3 Assets
 - [x] Models: `Asset`, `Price`, `AssetTransactionLink`.

--- a/backend/apps/accounting/serializers.py
+++ b/backend/apps/accounting/serializers.py
@@ -4,9 +4,11 @@ from .models import Account, Category, Journal, Transaction
 
 
 class AccountSerializer(serializers.ModelSerializer):
+    balance = serializers.DecimalField(max_digits=10, decimal_places=2, read_only=True)
+
     class Meta:
         model = Account
-        fields = ["id", "name", "type"]
+        fields = ["id", "name", "type", "balance"]
 
 
 class CategorySerializer(serializers.ModelSerializer):

--- a/backend/apps/accounting/tests.py
+++ b/backend/apps/accounting/tests.py
@@ -1,6 +1,10 @@
+from decimal import Decimal
+
 from apps.core.models import User
 from apps.families.models import Family, Membership
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
+from rest_framework.test import APIClient
 
 from .models import Account, Category, Journal, Transaction
 
@@ -33,3 +37,65 @@ class AccountingModelTests(TestCase):
         )
         self.assertEqual(tx.debit_account, debit)
         self.assertEqual(tx.credit_account, credit)
+
+    def test_account_balance(self):
+        debit = Account.objects.create(
+            family=self.family, name="Cash", type=Account.Type.ASSET
+        )
+        credit = Account.objects.create(
+            family=self.family, name="Income", type=Account.Type.INCOME
+        )
+        Transaction.objects.create(
+            family=self.family,
+            description="Payday",
+            amount="50.00",
+            debit_account=debit,
+            credit_account=credit,
+        )
+        self.assertEqual(debit.balance, Decimal("50.00"))
+        self.assertEqual(credit.balance, Decimal("-50.00"))
+
+    def test_invalid_transaction_same_account(self):
+        acct = Account.objects.create(
+            family=self.family, name="Cash", type=Account.Type.ASSET
+        )
+        with self.assertRaises(Exception):
+            Transaction.objects.create(
+                family=self.family,
+                description="bad",
+                amount="10.00",
+                debit_account=acct,
+                credit_account=acct,
+            )
+
+
+class AccountingAPITests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user("parent@example.com", "pass")
+        self.family = Family.objects.create(name="Jones", owner=self.user)
+        Membership.objects.create(
+            user=self.user, family=self.family, role=Membership.Role.PARENT
+        )
+        self.client.force_authenticate(user=self.user)
+        self.debit = Account.objects.create(
+            family=self.family, name="Cash", type=Account.Type.ASSET
+        )
+        self.credit = Account.objects.create(
+            family=self.family, name="Income", type=Account.Type.INCOME
+        )
+
+    def test_import_and_export_csv(self):
+        csv_content = (
+            "description,amount,debit_account,credit_account\n"
+            f"Pay,20.00,{self.debit.id},{self.credit.id}\n"
+        )
+        file = SimpleUploadedFile(
+            "tx.csv", csv_content.encode(), content_type="text/csv"
+        )
+        response = self.client.post("/api/transactions/import_csv/", {"file": file})
+        self.assertEqual(response.status_code, 201)
+        resp = self.client.get("/api/transactions/export_csv/")
+        self.assertEqual(resp.status_code, 200)
+        content = b"".join(resp.streaming_content).decode()
+        self.assertIn("Pay", content)

--- a/backend/apps/accounting/views.py
+++ b/backend/apps/accounting/views.py
@@ -1,4 +1,9 @@
-from rest_framework import permissions, viewsets
+import csv
+
+from django.http import StreamingHttpResponse
+from rest_framework import permissions, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
 
 from .models import Account, Category, Journal, Transaction
 from .serializers import (
@@ -15,7 +20,7 @@ class AccountViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.IsAuthenticated]
 
     def perform_create(self, serializer):
-        serializer.save(family=self.request.user.memberships.first().family)
+        serializer.save(family=self.request.user.membership_set.first().family)
 
 
 class CategoryViewSet(viewsets.ModelViewSet):
@@ -24,7 +29,7 @@ class CategoryViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.IsAuthenticated]
 
     def perform_create(self, serializer):
-        serializer.save(family=self.request.user.memberships.first().family)
+        serializer.save(family=self.request.user.membership_set.first().family)
 
 
 class JournalViewSet(viewsets.ModelViewSet):
@@ -33,7 +38,7 @@ class JournalViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.IsAuthenticated]
 
     def perform_create(self, serializer):
-        serializer.save(family=self.request.user.memberships.first().family)
+        serializer.save(family=self.request.user.membership_set.first().family)
 
 
 class TransactionViewSet(viewsets.ModelViewSet):
@@ -42,4 +47,61 @@ class TransactionViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.IsAuthenticated]
 
     def perform_create(self, serializer):
-        serializer.save(family=self.request.user.memberships.first().family)
+        serializer.save(family=self.request.user.membership_set.first().family)
+
+    @action(detail=False, methods=["post"])
+    def import_csv(self, request):
+        family = request.user.membership_set.first().family
+        uploaded = request.FILES.get("file")
+        if not uploaded:
+            return Response(
+                {"detail": "No file provided"}, status=status.HTTP_400_BAD_REQUEST
+            )
+        decoded = uploaded.read().decode("utf-8").splitlines()
+        reader = csv.DictReader(decoded)
+        created = 0
+        for row in reader:
+            Transaction.objects.create(
+                family=family,
+                description=row["description"],
+                amount=row["amount"],
+                debit_account_id=row["debit_account"],
+                credit_account_id=row["credit_account"],
+                category_id=row.get("category") or None,
+                journal_id=row.get("journal") or None,
+            )
+            created += 1
+        return Response({"created": created}, status=status.HTTP_201_CREATED)
+
+    @action(detail=False, methods=["get"])
+    def export_csv(self, request):
+        family = request.user.membership_set.first().family
+        queryset = Transaction.objects.filter(family=family).order_by("id")
+
+        headers = [
+            "id",
+            "description",
+            "amount",
+            "debit_account",
+            "credit_account",
+            "category",
+            "journal",
+        ]
+
+        def generate():
+            yield ",".join(headers) + "\n"
+            for tx in queryset:
+                row = [
+                    str(tx.id),
+                    tx.description,
+                    str(tx.amount),
+                    str(tx.debit_account_id),
+                    str(tx.credit_account_id),
+                    str(tx.category_id or ""),
+                    str(tx.journal_id or ""),
+                ]
+                yield ",".join(row) + "\n"
+
+        response = StreamingHttpResponse(generate(), content_type="text/csv")
+        response["Content-Disposition"] = "attachment; filename=transactions.csv"
+        return response

--- a/backend/apps/assets/views.py
+++ b/backend/apps/assets/views.py
@@ -1,10 +1,10 @@
 from rest_framework import permissions, viewsets
 
-from .models import Asset, Price, AssetTransactionLink
+from .models import Asset, AssetTransactionLink, Price
 from .serializers import (
     AssetSerializer,
-    PriceSerializer,
     AssetTransactionLinkSerializer,
+    PriceSerializer,
 )
 
 
@@ -14,7 +14,7 @@ class AssetViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.IsAuthenticated]
 
     def perform_create(self, serializer):
-        serializer.save(family=self.request.user.memberships.first().family)
+        serializer.save(family=self.request.user.membership_set.first().family)
 
 
 class PriceViewSet(viewsets.ReadOnlyModelViewSet):
@@ -29,4 +29,4 @@ class AssetTransactionLinkViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.IsAuthenticated]
 
     def perform_create(self, serializer):
-        serializer.save(family=self.request.user.memberships.first().family)
+        serializer.save(family=self.request.user.membership_set.first().family)

--- a/backend/apps/chores/views.py
+++ b/backend/apps/chores/views.py
@@ -1,4 +1,4 @@
-from rest_framework import permissions, viewsets, status
+from rest_framework import permissions, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
@@ -12,7 +12,7 @@ class ChoreViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.IsAuthenticated]
 
     def perform_create(self, serializer):
-        serializer.save(family=self.request.user.memberships.first().family)
+        serializer.save(family=self.request.user.membership_set.first().family)
 
 
 class EntryViewSet(viewsets.ModelViewSet):
@@ -21,7 +21,7 @@ class EntryViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.IsAuthenticated]
 
     def perform_create(self, serializer):
-        serializer.save(family=self.request.user.memberships.first().family)
+        serializer.save(family=self.request.user.membership_set.first().family)
 
     @action(detail=True, methods=["post"])
     def approve(self, request, pk=None):


### PR DESCRIPTION
## Summary
- add Account.balance helper and Transaction validations
- expose balance in AccountSerializer
- add CSV import/export actions
- mark accounting tasks complete
- fix membership related_name usage
- test new accounting API

## Testing
- `pre-commit run --files backend/apps/chores/views.py backend/apps/accounting/views.py backend/apps/assets/views.py backend/apps/accounting/models.py backend/apps/accounting/serializers.py backend/apps/accounting/tests.py`
- `./scripts/run_tests_sqlite.sh`

------
https://chatgpt.com/codex/tasks/task_e_686a43fae13c8320aab24cb4b8cdcd90