### PR TITLE
Add reject action and update chore dashboard

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -50,7 +50,7 @@
 - [x] Setup React Router, TanStack Query & JWT auth hooks.
 
 ## Phase 4 – Frontend Features
-- [ ] Chore dashboard & approval modals.
+- [x] Chore dashboard & approval modals.
 - [ ] Transaction ledger with category filter/tagging.
 - [ ] Asset portfolio table & charts.
 - [ ] Family administration pages.

--- a/backend/apps/chores/tests.py
+++ b/backend/apps/chores/tests.py
@@ -68,6 +68,24 @@ class ChoreAPITests(TestCase):
         entry.refresh_from_db()
         self.assertEqual(entry.status, Entry.Status.APPROVED)
 
+    def test_reject_entry(self):
+        chore = Chore.objects.create(
+            family=self.family,
+            name="Sweep",
+            schedule="daily",
+            points=1,
+        )
+        entry = Entry.objects.create(
+            family=self.family,
+            chore=chore,
+            assigned_to=self.user,
+            due_date=date.today(),
+        )
+        response = self.client.post(f"/api/chore-entries/{entry.id}/reject/")
+        self.assertEqual(response.status_code, 200)
+        entry.refresh_from_db()
+        self.assertEqual(entry.status, Entry.Status.REJECTED)
+
     def test_exchange_points_service(self):
         chore = Chore.objects.create(
             family=self.family,

--- a/backend/apps/chores/views.py
+++ b/backend/apps/chores/views.py
@@ -33,6 +33,14 @@ class EntryViewSet(FamilyQuerySetMixin, viewsets.ModelViewSet):
         entry.save(update_fields=["status"])
         return Response({"status": entry.status}, status=status.HTTP_200_OK)
 
+    @action(detail=True, methods=["post"])
+    def reject(self, request, pk=None):
+        """Reject a completed entry."""
+        entry = self.get_object()
+        entry.status = Entry.Status.REJECTED
+        entry.save(update_fields=["status"])
+        return Response({"status": entry.status}, status=status.HTTP_200_OK)
+
     @action(detail=False, methods=["post"])
     def exchange_points(self, request):
         account_id = request.data.get("account")

--- a/doc/chores.md
+++ b/doc/chores.md
@@ -13,6 +13,7 @@ Detailed breakdown of the chores domain.
 - `PATCH /api/chores/{id}/` – update or archive a chore.
 - `POST /api/chore-entries/` – log completion of a chore entry.
 - `POST /api/chore-entries/{id}/approve/` – parent approval action.
+- `POST /api/chore-entries/{id}/reject/` – reject a completed entry.
 
 ## Background Tasks
 - Celery beat job spawns `Entry` records based on each `Chore`'s schedule.

--- a/frontend/src/features/chores/ChoreDashboard.tsx
+++ b/frontend/src/features/chores/ChoreDashboard.tsx
@@ -28,6 +28,13 @@ export default function ChoreDashboard() {
     },
   );
 
+  const rejectMutation = useMutation(
+    (id: number) => api.post(`/chore-entries/${id}/reject/`),
+    {
+      onSuccess: () => queryClient.invalidateQueries(['chore-entries']),
+    },
+  );
+
   const [selected, setSelected] = useState<Entry | null>(null);
 
   return (
@@ -59,7 +66,7 @@ export default function ChoreDashboard() {
                       onClick={() => setSelected(e)}
                       className="text-blue-600 underline"
                     >
-                      Approve
+                      Review
                     </button>
                   )}
                 </td>
@@ -74,8 +81,10 @@ export default function ChoreDashboard() {
           open
           className="fixed inset-0 bg-black/50 flex items-center justify-center"
         >
-          <div className="bg-white dark:bg-gray-800 p-4 rounded w-64">
-            <p className="mb-4">Approve entry #{selected.id}?</p>
+          <div className="bg-white dark:bg-gray-800 p-4 rounded w-72">
+            <p className="mb-4">
+              Approve or reject entry #{selected.id}?
+            </p>
             <div className="flex justify-end gap-2">
               <button
                 onClick={() => {
@@ -85,6 +94,15 @@ export default function ChoreDashboard() {
                 className="px-3 py-1 rounded bg-blue-500 text-white"
               >
                 Approve
+              </button>
+              <button
+                onClick={() => {
+                  rejectMutation.mutate(selected.id);
+                  setSelected(null);
+                }}
+                className="px-3 py-1 rounded bg-red-500 text-white"
+              >
+                Reject
               </button>
               <button
                 onClick={() => setSelected(null)}


### PR DESCRIPTION
## Summary
- implement ability to reject chore entries
- update chore documentation
- allow approving or rejecting entries from the frontend dashboard
- mark the chore dashboard task as complete
- test new endpoint with Django tests

## Testing
- `./scripts/run_tests_sqlite.sh`
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_686a5c2fa22c8320bdadb17e2bf0a3ad