### PR TITLE
Implement transaction ledger with category filtering

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -51,7 +51,7 @@
 
 ## Phase 4 – Frontend Features
 - [x] Chore dashboard & approval modals.
-- [ ] Transaction ledger with category filter/tagging.
+- [x] Transaction ledger with category filter/tagging.
 - [ ] Asset portfolio table & charts.
 - [ ] Family administration pages.
 

--- a/backend/apps/accounting/tests.py
+++ b/backend/apps/accounting/tests.py
@@ -122,3 +122,27 @@ class AccountingAPITests(TestCase):
         self.assertEqual(resp.status_code, 200)
         content = b"".join(resp.streaming_content).decode()
         self.assertIn("Pay", content)
+
+    def test_filter_transactions_by_category(self):
+        cat1 = Category.objects.create(family=self.family, name="Food")
+        cat2 = Category.objects.create(family=self.family, name="Fun")
+        Transaction.objects.create(
+            family=self.family,
+            description="Pizza",
+            amount="10.00",
+            debit_account=self.debit,
+            credit_account=self.credit,
+            category=cat1,
+        )
+        Transaction.objects.create(
+            family=self.family,
+            description="Movie",
+            amount="15.00",
+            debit_account=self.debit,
+            credit_account=self.credit,
+            category=cat2,
+        )
+        resp = self.client.get(f"/api/transactions/?category={cat1.id}")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(resp.data), 1)
+        self.assertEqual(resp.data[0]["category"], cat1.id)

--- a/backend/apps/accounting/views.py
+++ b/backend/apps/accounting/views.py
@@ -47,6 +47,13 @@ class TransactionViewSet(FamilyQuerySetMixin, viewsets.ModelViewSet):
     serializer_class = TransactionSerializer
     permission_classes = [permissions.IsAuthenticated]
 
+    def get_queryset(self):
+        qs = super().get_queryset()
+        category = self.request.query_params.get("category")
+        if category:
+            qs = qs.filter(category_id=category)
+        return qs
+
     def perform_create(self, serializer):
         serializer.save(family=self.request.user.membership_set.first().family)
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { Route, Routes, Link } from 'react-router-dom';
 import { ChoreDashboard } from './features/chores';
+import { TransactionLedger } from './features/transactions';
 
 const Home = () => (
   <div className="p-4">
@@ -10,6 +11,11 @@ const Home = () => (
         Go to Chores
       </Link>
     </p>
+    <p className="mt-2">
+      <Link to="/transactions" className="underline text-blue-600">
+        Go to Transactions
+      </Link>
+    </p>
   </div>
 );
 
@@ -18,6 +24,7 @@ export default function App() {
     <Routes>
       <Route path="/" element={<Home />} />
       <Route path="/chores" element={<ChoreDashboard />} />
+      <Route path="/transactions" element={<TransactionLedger />} />
       <Route
         path="*"
         element={

--- a/frontend/src/features/transactions/TransactionLedger.tsx
+++ b/frontend/src/features/transactions/TransactionLedger.tsx
@@ -1,0 +1,118 @@
+import { useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { api } from '../../lib/api';
+
+interface Transaction {
+  id: number;
+  description: string;
+  amount: string;
+  debit_account: number;
+  credit_account: number;
+  category: number | null;
+}
+
+interface Category {
+  id: number;
+  name: string;
+}
+
+export default function TransactionLedger() {
+  const queryClient = useQueryClient();
+  const [categoryFilter, setCategoryFilter] = useState<number | 'all'>('all');
+
+  const { data: categories } = useQuery<Category[]>(
+    ['categories'],
+    async () => {
+      const res = await api.get('/categories/');
+      return res.data as Category[];
+    },
+  );
+
+  const { data: transactions, isLoading } = useQuery<Transaction[]>(
+    ['transactions', categoryFilter],
+    async () => {
+      const res = await api.get('/transactions/', {
+        params: categoryFilter === 'all' ? {} : { category: categoryFilter },
+      });
+      return res.data as Transaction[];
+    },
+  );
+
+  const updateCategory = useMutation(
+    ({ id, category }: { id: number; category: number | null }) =>
+      api.patch(`/transactions/${id}/`, { category }),
+    {
+      onSuccess: () =>
+        queryClient.invalidateQueries(['transactions', categoryFilter]),
+    },
+  );
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Transaction Ledger</h1>
+      <div className="mb-4">
+        <label className="mr-2">Filter by Category:</label>
+        <select
+          value={categoryFilter}
+          onChange={(e) =>
+            setCategoryFilter(
+              e.target.value === 'all' ? 'all' : Number(e.target.value),
+            )
+          }
+          className="border px-2 py-1"
+        >
+          <option value="all">All</option>
+          {categories?.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      {isLoading ? (
+        <p>Loading...</p>
+      ) : (
+        <table className="min-w-full border">
+          <thead>
+            <tr className="bg-gray-100">
+              <th className="p-2 text-left">ID</th>
+              <th className="p-2 text-left">Description</th>
+              <th className="p-2 text-left">Amount</th>
+              <th className="p-2 text-left">Category</th>
+            </tr>
+          </thead>
+          <tbody>
+            {transactions?.map((tx) => (
+              <tr key={tx.id} className="border-t">
+                <td className="p-2">{tx.id}</td>
+                <td className="p-2">{tx.description}</td>
+                <td className="p-2">{tx.amount}</td>
+                <td className="p-2">
+                  <select
+                    value={tx.category ?? ''}
+                    onChange={(e) =>
+                      updateCategory.mutate({
+                        id: tx.id,
+                        category: e.target.value
+                          ? Number(e.target.value)
+                          : null,
+                      })
+                    }
+                    className="border px-2 py-1"
+                  >
+                    <option value="">None</option>
+                    {categories?.map((c) => (
+                      <option key={c.id} value={c.id}>
+                        {c.name}
+                      </option>
+                    ))}
+                  </select>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/transactions/index.ts
+++ b/frontend/src/features/transactions/index.ts
@@ -1,0 +1,1 @@
+export { default as TransactionLedger } from './TransactionLedger';


### PR DESCRIPTION
## Summary
- add category filter to `TransactionViewSet`
- test filtering transactions by category
- implement `TransactionLedger` React component
- add navigation link and route
- mark roadmap item as done

## Testing
- `pre-commit run --files backend/apps/accounting/views.py backend/apps/accounting/tests.py frontend/src/features/transactions/TransactionLedger.tsx frontend/src/features/transactions/index.ts frontend/src/App.tsx`
- `./scripts/run_tests_sqlite.sh`


------
https://chatgpt.com/codex/tasks/task_e_686a5ebdbc208320b11c2fdbf91ee293