### PR TITLE
Add frontend family admin pages

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -52,8 +52,8 @@
 ## Phase 4 – Frontend Features
 - [x] Chore dashboard & approval modals.
 - [x] Transaction ledger with category filter/tagging.
- - [x] Asset portfolio table & charts.
-- [ ] Family administration pages.
+- [x] Asset portfolio table & charts.
+- [x] Family administration pages.
 
 ## Phase 5 – Polish & Deployment
 - [ ] Add E2E tests (Playwright / Cypress).

--- a/doc/DETAILED_TASKS.md
+++ b/doc/DETAILED_TASKS.md
@@ -55,7 +55,7 @@ This document expands the high-level items in `TASKS.md`.
 - Chore dashboard with approval modals.
 - Transaction ledger with category filtering and tagging.
 - Asset portfolio table and charts. ✅
-- Family administration pages.
+- Family administration pages. ✅
 
 ## Phase 5 – Polish & Deployment
 - Add E2E tests using Playwright or Cypress.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { Route, Routes, Link } from 'react-router-dom';
 import { ChoreDashboard } from './features/chores';
 import { TransactionLedger } from './features/transactions';
 import { AssetPortfolio } from './features/assets';
+import { FamilyAdmin } from './features/families';
 
 const Home = () => (
   <div className="p-4">
@@ -22,6 +23,11 @@ const Home = () => (
         Go to Assets
       </Link>
     </p>
+    <p className="mt-2">
+      <Link to="/families" className="underline text-blue-600">
+        Go to Families
+      </Link>
+    </p>
   </div>
 );
 
@@ -32,6 +38,7 @@ export default function App() {
       <Route path="/chores" element={<ChoreDashboard />} />
       <Route path="/transactions" element={<TransactionLedger />} />
       <Route path="/assets" element={<AssetPortfolio />} />
+      <Route path="/families" element={<FamilyAdmin />} />
       <Route
         path="*"
         element={

--- a/frontend/src/features/families/FamilyAdmin.tsx
+++ b/frontend/src/features/families/FamilyAdmin.tsx
@@ -1,0 +1,142 @@
+import { useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { api } from '../../lib/api';
+
+interface Family {
+  id: number;
+  name: string;
+  settings_json: Record<string, unknown>;
+}
+
+export default function FamilyAdmin() {
+  const queryClient = useQueryClient();
+  const { data: families, isLoading } = useQuery<Family[]>(
+    ['families'],
+    async () => {
+      const res = await api.get('/families/');
+      return res.data as Family[];
+    },
+  );
+
+  const createFamily = useMutation(
+    (name: string) => api.post('/families/', { name }),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(['families']);
+        setNewName('');
+      },
+    },
+  );
+
+  const updateFamily = useMutation(
+    ({ id, name }: { id: number; name: string }) =>
+      api.patch(`/families/${id}/`, { name }),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(['families']);
+        setEditFamily(null);
+      },
+    },
+  );
+
+  const deleteFamily = useMutation(
+    (id: number) => api.delete(`/families/${id}/`),
+    {
+      onSuccess: () => queryClient.invalidateQueries(['families']),
+    },
+  );
+
+  const [newName, setNewName] = useState('');
+  const [editFamily, setEditFamily] = useState<Family | null>(null);
+  const [editName, setEditName] = useState('');
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Family Administration</h1>
+      <div className="mb-4 flex gap-2">
+        <input
+          value={newName}
+          onChange={(e) => setNewName(e.target.value)}
+          placeholder="New family name"
+          className="border px-2 py-1"
+        />
+        <button
+          onClick={() => newName && createFamily.mutate(newName)}
+          className="px-3 py-1 rounded bg-blue-500 text-white"
+        >
+          Add
+        </button>
+      </div>
+      {isLoading ? (
+        <p>Loading...</p>
+      ) : (
+        <table className="min-w-full border">
+          <thead>
+            <tr className="bg-gray-100">
+              <th className="p-2 text-left">ID</th>
+              <th className="p-2 text-left">Name</th>
+              <th className="p-2" />
+            </tr>
+          </thead>
+          <tbody>
+            {families?.map((fam) => (
+              <tr key={fam.id} className="border-t">
+                <td className="p-2">{fam.id}</td>
+                <td className="p-2">{fam.name}</td>
+                <td className="p-2 text-right space-x-2">
+                  <button
+                    onClick={() => {
+                      setEditFamily(fam);
+                      setEditName(fam.name);
+                    }}
+                    className="underline text-blue-600"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    onClick={() => deleteFamily.mutate(fam.id)}
+                    className="underline text-red-600"
+                  >
+                    Delete
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {editFamily && (
+        <dialog
+          open
+          className="fixed inset-0 bg-black/50 flex items-center justify-center"
+        >
+          <div className="bg-white dark:bg-gray-800 p-4 rounded w-72">
+            <p className="mb-2">Edit family {editFamily.name}</p>
+            <input
+              value={editName}
+              onChange={(e) => setEditName(e.target.value)}
+              className="border px-2 py-1 w-full mb-4"
+            />
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() =>
+                  updateFamily.mutate({ id: editFamily.id, name: editName })
+                }
+                className="px-3 py-1 rounded bg-blue-500 text-white"
+              >
+                Save
+              </button>
+              <button
+                onClick={() => setEditFamily(null)}
+                className="px-3 py-1 rounded border"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </dialog>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/families/index.ts
+++ b/frontend/src/features/families/index.ts
@@ -1,0 +1,1 @@
+export { default as FamilyAdmin } from './FamilyAdmin';


### PR DESCRIPTION
## Summary
- implement `FamilyAdmin` with CRUD actions
- expose `FamilyAdmin` via new route and link
- mark family admin pages as complete in docs

## Testing
- `pre-commit run --files TASKS.md doc/DETAILED_TASKS.md frontend/src/App.tsx frontend/src/features/families/FamilyAdmin.tsx frontend/src/features/families/index.ts`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686a6bda5bc8832099b5de55f4b0e16f